### PR TITLE
Make players able to clear selections

### DIFF
--- a/permissions.yml
+++ b/permissions.yml
@@ -108,6 +108,7 @@ op:
       worldedit.selection.inset: true
       worldedit.analysis.distr: true
       worldedit.analysis.count: true
+      worldedit.analysis.sel: true
       worldedit.selection.size: true
       worldedit.selection.expand: true
       worldedit.selection.shift: true


### PR DESCRIPTION
Please, some people use WorldEditCUI and as such don't want to see old world edits from thousands of blocks away