### PR TITLE
Fix worldedit permissions

### DIFF
--- a/permissions.yml
+++ b/permissions.yml
@@ -211,7 +211,6 @@ op:
       worldedit.threads: true
       worldedit.transforms: true
       worldedit.toggleplace: true
-      worldedit.regen: true
       worldedit.setwand: true
 
 deop:

--- a/permissions.yml
+++ b/permissions.yml
@@ -170,6 +170,7 @@ op:
       worldedit.brush.options.transform: true
       worldedit.brush.options.scroll: true
       worldedit.brush.options.visualize: true
+      worldedit.brush.options.tracemask: true
       worldedit.tool.deltree: true
       worldedit.tool.farwand: true
       worldedit.tool.lrbuild: true
@@ -209,6 +210,9 @@ op:
       worldedit.remove: true
       worldedit.threads: true
       worldedit.transforms: true
+      worldedit.toggleplace: true
+      worldedit.regen: true
+      worldedit.setwand: true
 
 deop:
   default: not-op

--- a/permissions.yml
+++ b/permissions.yml
@@ -179,6 +179,7 @@ op:
       worldedit.tool.data-cycler: true
       worldedit.tool.flood-fill: true
       worldedit.tool.inspect: true
+      worldedit.tool.none: true
       worldedit.light.fix: true
       worldedit.light.remove: true
       worldedit.light.set: true


### PR DESCRIPTION
Worldedit was missing some permissions. I think the most notable ones were `worldedit.regen` and `worldedit.tool.none`.