### PR TITLE
Allow people to upload schematics to the server

### DIFF
--- a/permissions.yml
+++ b/permissions.yml
@@ -212,6 +212,13 @@ op:
       worldedit.transforms: true
       worldedit.toggleplace: true
       worldedit.setwand: true
+      worldedit.clipboard.save: true
+      worldedit.schematic.delete: true
+      worldedit.schematic.move: true
+      worldedit.schematic.move.other: true
+      worldedit.clipboard.load: true
+      worldedit.schematic.load.other: true
+      worldedit.schematic.save.other: true
 
 deop:
   default: not-op


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/83607009/131162642-f991c619-4261-4096-8f05-777e50998e18.png)
Worldedit doesn't allow people to upload schematics if they don't have these permissions.