### PR TITLE
Alias `item` to `minecraft:item`

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -72,6 +72,8 @@ aliases:
   - minecraft:give $1-
   help:
   - bukkit:help $1-
+  item:
+  - minecraft:item $1-
   kick:
   - minecraft:kick $1-
   kill:


### PR DESCRIPTION
This aliases an `item` command to the `minecraft:item` command, to fix essentials replacing the vanilla `item` command.