### PR TITLE
Alias `w` to `minecraft:w`

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -144,6 +144,8 @@ aliases:
   - tp $1-
   tpall:
   - tp $1-
+  w:
+  - minecraft:w $1-
   weather:
   - minecraft:weather $1-
   xp:


### PR DESCRIPTION
This fixes essentials overriding yet another command.