### PR TITLE
Don't hide vanished users, but give the invisibily effect instead

### DIFF
--- a/permissions.yml
+++ b/permissions.yml
@@ -21,9 +21,9 @@ op:
       essentials.sudo.exempt: false
       essentials.tempban.exempt: false
       essentials.updatecheck: false
-      essentials.vanish.effect: false
+      # essentials.vanish.effect: false
       essentials.vanish.interact: false
-      essentials.vanish.see: false
+      # essentials.vanish.see: false
       geyser.command.reload: false
       geyser.command.stop: false
 


### PR DESCRIPTION
This is a temporary fix to 1.19.3 clients disconnecting with `Chat message validation failure` when a vanished user chats. The cause is the client not being able to find the player who sent the message in the player list. While it is likely possible to not send other clients their player entity while keeping them in the player list, I am not sure if Essentials supports such behavior.