### PR TITLE
Always use development versions of ViaVersion

### DIFF
--- a/scripts/fetch_external_plugins.sh
+++ b/scripts/fetch_external_plugins.sh
@@ -8,9 +8,9 @@ mkdir -p fetched_plugins
 for download_url in https://ci.ender.zone/job/EssentialsX/lastSuccessfulBuild/artifact/*zip*/archive.zip \
                     https://ci.athion.net/job/FastAsyncWorldEdit/lastSuccessfulBuild/artifact/*zip*/archive.zip \
                     https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/master/lastSuccessfulBuild/artifact/*zip*/archive.zip \
-                    https://ci.viaversion.com/job/ViaVersion/lastSuccessfulBuild/artifact/*zip*/archive.zip \
-                    https://ci.viaversion.com/job/ViaBackwards/lastSuccessfulBuild/artifact/*zip*/archive.zip \
-                    https://ci.viaversion.com/job/ViaRewind/lastSuccessfulBuild/artifact/*zip*/archive.zip
+                    https://ci.viaversion.com/job/ViaVersion-DEV/lastSuccessfulBuild/artifact/*zip*/archive.zip \
+                    https://ci.viaversion.com/job/ViaBackwards-DEV/lastSuccessfulBuild/artifact/*zip*/archive.zip \
+                    https://ci.viaversion.com/job/ViaRewind-DEV/lastSuccessfulBuild/artifact/*zip*/archive.zip
 do
     curl -L $download_url > archive.zip
     unzip -o archive.zip


### PR DESCRIPTION
The current release version of ViaRewind is broken with ViaVersion, as evidenced by the plugin being disabled in Kaboom production (and the related exception printed in console when it launches).

I've changed all Via* artifacts to their developer versions, not just ViaRewind and/or ViaVersion to minimize the possibility of any API version shenanigans.