### PR TITLE
block /tick

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -154,4 +154,8 @@ aliases:
   - minecraft:weather $1-
   xp:
   - minecraft:xp $1-
+  tick:
+  - []
+  minecraft:tick:
+  - []
 unrestricted-advancements: false


### PR DESCRIPTION
`/tick` has been abused hella lots through `/tick freeze` or `/tick rate 1` so I decided to make a pull request to block it