### PR TITLE
Block /return

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -158,4 +158,8 @@ aliases:
   - []
   minecraft:tick:
   - []
+  return:
+  - []
+  minecraft:return:
+  - []
 unrestricted-advancements: false


### PR DESCRIPTION
Using `/return`, you can do `/return run ${command}` and run vanilla commands without restrictions.