### PR TITLE
Remove the command block update ratelimit

### DIFF
--- a/config/paper-global.yml
+++ b/config/paper-global.yml
@@ -93,14 +93,6 @@ packet-limiter:
       action: DROP
       interval: 4.0
       max-packet-rate: 5.0
-    ServerboundSetCommandBlockPacket:
-      action: DROP
-      interval: 1.0
-      max-packet-rate: 101.0
-    ServerboundSetCommandMinecartPacket:
-      action: DROP
-      interval: 1.0
-      max-packet-rate: 101.0
     ServerboundSetJigsawBlockPacket:
       action: DROP
       interval: 1.0


### PR DESCRIPTION
As you may know, #110 added a command block ratelimit. Although this prevents spam, it has also caused problems with:
* Playing certain songs (via `playsound`)
* Rendering images
* Building structures (with `setblock` and `fill`)
* Possibly more

These are things I enjoy the freedom of being able to do, and the core ratelimit makes them hard to impossible. If this is merged, the server will be more fun to play on in my opinion. Many clones have already removed the ratelimit, anyway.