### PR TITLE
Block save-all

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -162,4 +162,8 @@ aliases:
   - []
   minecraft:return:
   - []
+  save-all:
+  - []
+  minecraft:save-all:
+  - []
 unrestricted-advancements: false


### PR DESCRIPTION
Save-all can be abused to lag and/or crash the server when spammed.