### PR TITLE
Don't map minecraft:teleport to the eseentials version of the command

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -127,8 +127,6 @@ aliases:
   - bcv Stopping the server
   tag:
   - minecraft:tag $1-
-  minecraft:teleport:
-  - tp $1-
   teleport:
   - tp $1-
   tell:
@@ -137,8 +135,6 @@ aliases:
   - minecraft:tellraw $1-
   time:
   - minecraft:time $1-
-  minecraft:tp:
-  - tp $1-
   essentials:etpall:
   - tp $1-
   essentials:tpall:


### PR DESCRIPTION
By blocking access to the standard Minecraft /teleport command, you're essentially limiting selectors and teleporting to entities (you can't teleport to entities with the essentials command, even with the UUID)

For example, I was trying to make a command block that would teleport a player to a specific entity that's attached to a fence using lead, but it kept on spitting out "Player not found" errors on the first argument that had the entity UUID