### PR TITLE
Disable the /datapack command

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -161,4 +161,8 @@ aliases:
   - []
   minecraft:return:
   - []
+  datapack:
+  - []
+  minecraft:datapack:
+  - []
 unrestricted-advancements: false


### PR DESCRIPTION
The /datapack list command is useless, and the other 2 subcommands (/datapack enable and /datapack disable) can be used to cause huge lag on the server and some lag on the client if spammed.