### PR TITLE
Config updates

### DIFF
--- a/plugins/Essentials/config.yml
+++ b/plugins/Essentials/config.yml
@@ -4,6 +4,9 @@
 # +------------------------------------------------------+ #
 ############################################################
 
+# This is the config file for EssentialsX.
+# This config was generated for version 2.21.0-dev+151-f2af952.
+
 # If you want to use special characters in this document, such as accented letters, you MUST save the file as UTF-8, not ANSI.
 # If you receive an error when Essentials loads, ensure that:
 #   - No tabs are present: YAML only allows spaces
@@ -11,11 +14,7 @@
 #   - You have "escaped" all apostrophes in your text: If you want to write "don't", for example, write "don''t" instead (note the doubled apostrophe)
 #   - Text with symbols is enclosed in single or double quotation marks
 
-# If you have problems join the Essentials help support channel: http://tiny.cc/EssentialsChat
-
-# Version 2.16.1.209
-
-# KITS ARE NOW IN THE kits.yml FILE
+# If you need help, you can join the EssentialsX community: https://essentialsx.net/community.html
 
 ############################################################
 # +------------------------------------------------------+ #
@@ -23,16 +22,22 @@
 # +------------------------------------------------------+ #
 ############################################################
 
-update-check: false
-
 # A color code between 0-9 or a-f. Set to 'none' to disable.
+# In 1.16+ you can use hex color codes here as well. (For example, #613e1d is brown).
 ops-name-color: 'c'
 
 # The character(s) to prefix all nicknames, so that you know they are not true usernames.
+# Users with essentials.nick.hideprefix will not be prefixed with the character(s)
 nickname-prefix: ''
 
-# The maximum length allowed in nicknames. The nickname prefix is included in this.
+# The maximum length allowed in nicknames. The nickname prefix is not included in this.
 max-nick-length: 99999
+
+# A list of phrases that cannot be used in nicknames. You can include regular expressions here.
+# Users with essentials.nick.blacklist.bypass will be able to bypass this filter.
+nick-blacklist:
+#- Notch
+#- '^Dinnerbone'
 
 # When this option is enabled, nickname length checking will exclude color codes in player names.
 # ie: "&6Notch" has 7 characters (2 are part of a color code), a length of 5 is used when this option is set to true
@@ -44,6 +49,9 @@ hide-displayname-in-vanish: true
 
 # Disable this if you have any other plugin, that modifies the displayname of a user.
 change-displayname: true
+
+# This option will cause Essentials to show players' displaynames instead of usernames when tab completing Essentials commands.
+change-tab-complete-name: false
 
 # When this option is enabled, the (tab) player list will be updated with the displayname.
 # The value of change-displayname (above) has to be true.
@@ -74,6 +82,15 @@ teleport-safety: true
 # teleport-safety and this option need to be set to true to force teleportation to dangerous locations.
 force-disable-teleport-safety: true
 
+# If a player is teleporting to an unsafe location in creative, adventure, or god mode; they will not be teleported to a
+# safe location. If you'd like players to be teleported to a safe location all of the time, set this option to true.
+force-safe-teleport-location: false
+
+# If a player has any passengers, the teleport will fail. Should their passengers be dismounted before they are teleported?
+# If this is set to true, Essentials will dismount the player's passengers before teleporting.
+# If this is set to false, attempted teleports will be canceled with a warning.
+teleport-passenger-dismount: true
+
 # The delay, in seconds, required between /home, /tp, etc.
 teleport-cooldown: 0
 
@@ -89,6 +106,9 @@ teleport-to-center: true
 
 # The delay, in seconds, required between /heal or /feed attempts.
 heal-cooldown: 0
+
+# Do you want to remove potion effects when healing a player?
+remove-effects-on-heal: true
 
 # Near Radius
 # The default radius with /near
@@ -141,7 +161,7 @@ notify-player-of-mail-cooldown: 60
 #
 # If you have two plugin with the same command and you wish to force Essentials to take over, you need an alias.
 # To force essentials to take 'god' alias 'god' to 'egod'.
-# See http://wiki.bukkit.org/Commands.yml#aliases for more information.
+# See https://bukkit.fandom.com/wiki/Commands.yml#aliases for more information.
 
 overridden-commands:
 #  - god
@@ -149,10 +169,14 @@ overridden-commands:
 
 # Disabling commands here will prevent Essentials handling the command, this will not affect command conflicts.
 # You should not have to disable commands used in other plugins, they will automatically get priority.
-# See http://wiki.bukkit.org/Commands.yml#aliases to map commands to other plugins.
+# See https://bukkit.fandom.com/wiki/Commands.yml#aliases to map commands to other plugins.
 disabled-commands:
 #  - nick
 #  - clear
+
+# Whether or not Essentials should show detailed command usages.
+# If set to false, Essentials will collapse all usages in to one single usage message.
+verbose-command-usages: true
 
 # These commands will be shown to players with socialSpy enabled.
 # You can add commands from other plugins you may want to track or
@@ -185,6 +209,26 @@ socialspy-commands:
 # If so, they will be differentiated from those sent by normal players.
 socialspy-listen-muted-players: true
 
+# Whether social spy should spy on private messages or just the commands from the list above.
+# If false, social spy will only monitor commands from the list above.
+socialspy-messages: true
+
+# Whether social spy should use formatted display names which may include color.
+# If false, social spy will use only the actual player names.
+socialspy-uses-displaynames: true
+
+# The following settings listen for when a player changes worlds.
+# If you use another plugin to control speed and flight, you should change these to false.
+
+# When a player changes world, should EssentialsX reset their flight?
+# This will disable flight if the player does not have essentials.fly.
+world-change-fly-reset: true
+
+# When a player changes world, should we reset their speed according to their permissions?
+# This resets the player's speed to the default if they don't have essentials.speed.
+# If the player doesn't have essentials.speed.bypass, this resets their speed to the maximum specified above.
+world-change-speed-reset: true
+
 # Mute Commands
 # These commands will be disabled when a player is muted.
 # Use '*' to disable every command.
@@ -207,11 +251,23 @@ use-bukkit-permissions: false
 # removed from the /kit list when a player can no longer use it
 skip-used-one-time-kits-from-kit-list: false
 
+# When enabled, armor from kits will automatically be equipped as long as the player's armor slots are empty.
+kit-auto-equip: false
+
 # Determines the functionality of the /createkit command.
 # If this is true, /createkit will give the user a link with the kit code.
 # If this is false, /createkit will add the kit to the kits.yml config file directly.
-#
+# Default is false.
 pastebin-createkit: false
+
+# Determines if /createkit will generate kits using NBT item serialization.
+# If this is true, /createkit will store items as NBT; otherwise, it will use Essentials' human-readable item format.
+# By using NBT serialization, /createkit can store items with complex metadata such as shulker boxes and weapons with custom attributes.
+# WARNING: This option only works on 1.15.2+ Paper servers, and it will bypass any custom serializers from other plugins such as Magic.
+# WARNING: When creating kits via /createkit with this option enabled, you will not be able to downgrade your server with these kit items.
+# This option only affects /createkit - you can still create kits by hand in `kits.yml` using Essentials' human-readable item format.
+# Default is false.
+use-nbt-serialization-in-createkit: false
 
 # Essentials Sign Control
 # See http://wiki.ess3.net/wiki/Sign_Tutorial for instructions on how to use these.
@@ -226,7 +282,6 @@ enabledSigns:
   - sell
   - trade
   - free
-  - disposal
   - warp
   - kit
   - mail
@@ -238,6 +293,14 @@ enabledSigns:
   - repair
   - time
   - weather
+  - anvil
+  - cartography
+  - disposal
+  - grindstone
+  - loom
+  - smithing
+  - workbench
+  - randomteleport
 
 # How many times per second can Essentials signs be interacted with per player.
 # Values should be between 1-20, 20 being virtually no lag protection.
@@ -258,12 +321,18 @@ allow-old-id-signs: false
 unprotected-sign-names:
   #- kit
 
-# Backup runs a batch/bash command while saving is disabled.
+# Backup runs a custom batch/bash command at a specified interval.
+# The server will save the world before executing the backup command, and disable
+# saving during the backup to prevent world corruption or other conflicts.
+# Backups can also be triggered manually with /backup.
 backup:
   # Interval in minutes.
   interval: 30
+  # If true, the backup task will run even if there are no players online.
+  always-run: false
   # Unless you add a valid backup command or script here, this feature will be useless.
   # Use 'save-all' to simply force regular world saving without backup.
+  # The example command below utilizes rdiff-backup: https://rdiff-backup.net/
   #command: 'rdiff-backup World1 backups/World1'
 
 # Set this true to enable permission per warp.
@@ -283,6 +352,9 @@ list:
     # Uncomment the line below to simply list all players with no grouping
     Players: '*'
 
+# Displays real names in /list next to players who are using a nickname.
+real-names-on-list: false
+
 # More output to the console.
 debug: false
 
@@ -290,8 +362,22 @@ debug: false
 # If you don't set this, the default locale of the server will be used.
 # For example, to set language to English, set locale to en, to use the file "messages_en.properties".
 # Don't forget to remove the # in front of the line.
-# For more information, visit http://wiki.ess3.net/wiki/Locale
+# For more information, visit https://essentialsx.net/wiki/Locale.html
 #locale: en
+
+# Should EssentialsX use player's language instead of the server's when sending messages?
+# This is useful if you want to use a different language for your server than for your players.
+# For example, if you have your server set to English and a player who speaks French, you can set this to true
+# and EssentialsX will send messages in French to the player and messages in the console as English.
+# If a player's language is not known, the server's language (or one defined above) will be used.
+per-player-locale: false
+
+# Change the default primary and secondary colours used in EssentialsX messages.
+# Some messages may use custom colours, which will need to be edited in the appropriate message files.
+# For more information on customising messages, see https://essentialsx.net/wiki/Locale.html
+message-colors:
+  primary: '#ffaa00'
+  secondary: '#ff5555'
 
 # Turn off god mode when people leave the server.
 remove-god-on-disconnect: false
@@ -327,31 +413,90 @@ cancel-afk-on-interact: true
 # Disable this to reduce server lag.
 cancel-afk-on-move: false
 
+# Should we automatically remove afk status when a player sends a chat message?
+cancel-afk-on-chat: true
+
 # Should AFK players be ignored when other players are trying to sleep?
 # When this setting is false, players won't be able to skip the night if some players are AFK.
 # Users with the permission node essentials.sleepingignored will always be ignored.
 sleep-ignores-afk-players: true
+
+# Should vanished players be ignored when other players are trying to sleep?
+# When this setting is false, player's won't be able to skip the night if vanished players are not sleeping.
+# Users with the permission node essentials.sleepingignored will always be ignored.
+sleep-ignores-vanished-player: true
 
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.
 # You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.
 afk-list-name: "none"
 
+# When a player enters or exits AFK mode, should the AFK notification be broadcast
+# to the entire server, or just to the player?
+# When this setting is false, only the player will be notified upon changing their AFK state.
+broadcast-afk-message: true
+
 # You can disable the death messages of Minecraft here.
 death-messages: true
+
+# How should essentials handle players with the essentials.keepinv permission who have items with
+# curse of vanishing when they die?
+# You can set this to "keep" (to keep the item), "drop" (to drop the item), or "delete" (to delete the item).
+# Defaults to "keep"
+vanishing-items-policy: keep
+
+# How should essentials handle players with the essentials.keepinv permission who have items with
+# curse of binding when they die?
+# You can set this to "keep" (to keep the item), "drop" (to drop the item), or "delete" (to delete the item).
+# Defaults to "keep"
+binding-items-policy: keep
+
+# When players die, should they receive the coordinates they died at?
+send-info-after-death: false
 
 # Should players with permissions be able to join and part silently?
 # You can control this with essentials.silentjoin and essentials.silentquit permissions if it is enabled.
 # In addition, people with essentials.silentjoin.vanish will be vanished on join.
 allow-silent-join-quit: false
 
-# You can set a custom join message here, set to "none" to disable.
-# You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.
-custom-join-message: "none"
+# You can set custom join and quit messages here. Set this to "none" to use the default Minecraft message,
+# or set this to "" to hide the message entirely.
 
-# You can set a custom quit message here, set to "none" to disable.
-# You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.
+# Available placeholders:
+# {PLAYER} - The player's displayname. 
+# {USERNAME} - The player's username.
+# {PREFIX} - The player's prefix.
+# {SUFFIX} - The player's suffix.
+# {ONLINE} - The number of players online.
+# {UNIQUE} - The number of unique players to join the server.
+# {UPTIME} - The amount of time the server has been online.
+custom-join-message: "none"
 custom-quit-message: "none"
+
+# You can set a custom join message for users who join with a new username here.
+# This message will only be used if a user has joined before and have since changed their username.
+# This will be displayed INSTEAD OF custom-join-message, so if you intend to keep them similar, make sure they match.
+# Set this to "none" to use the the "custom-join-message" above for every join.
+
+# Available placeholders:
+# {PLAYER} - The player's displayname. 
+# {USERNAME} - The player's username.
+# {OLDUSERNAME} - The player's old username.
+# {PREFIX} - The player's prefix.
+# {SUFFIX} - The player's suffix.
+# {ONLINE} - The number of players online.
+# {UNIQUE} - The number of unique players to join the server.
+# {UPTIME} - The amount of time the server has been online.
+custom-new-username-message: "none"
+
+# Should Essentials override the vanilla "Server Full" message with its own from the language file?
+# Set to false to keep the vanilla message.
+use-custom-server-full-message: true
+
+# You can disable join and quit messages when the player count reaches a certain limit.
+# When the player count is below this number, join/quit messages will always be shown.
+# Set this to -1 to always show join and quit messages regardless of player count.
+hide-join-quit-messages-above: -1
 
 # Add worlds to this list, if you want to automatically disable god mode there.
 no-god-in-worlds:
@@ -382,6 +527,9 @@ repair-enchanted: true
 # Warning: Mixing and overleveling some enchantments can cause issues with clients, servers and plugins.
 unsafe-enchantments: true
 
+# The maximum range from the player that the /tree and /bigtree commands can spawn trees.
+tree-command-range-limit: 300
+
 #Do you want Essentials to keep track of previous location for /back in the teleport listener?
 #If you set this to true any plugin that uses teleport will have the previous location registered.
 register-back-in-listener: true
@@ -398,11 +546,16 @@ max-walk-speed: 0.8
 #Set the maximum amount of mail that can be sent within a minute.
 mails-per-minute: 1000
 
+# Set the maximum time /mute can be used for in seconds.
+# Set to -1 to disable, and essentials.mute.unlimited can be used to override.
+max-mute-time: -1
+
 # Set the maximum time /tempban can be used for in seconds.
 # Set to -1 to disable, and essentials.tempban.unlimited can be used to override.
 max-tempban-time: -1
 
-# Changes /reply functionality. If true, /r goes to the person you messaged last, otherwise the first person that messaged you. 
+# Changes the default /reply functionality. This can be changed on a per-player basis using /rtoggle.
+# If true, /r goes to the person you messaged last, otherwise the first person that messaged you.
 # If false, /r goes to the last person that messaged you.
 last-message-reply-recipient: true
 
@@ -412,7 +565,12 @@ last-message-reply-recipient: true
 # Default is 180 (3 minutes)
 last-message-reply-recipient-timeout: 180
 
-# Toggles whether or not clicking mobs with a milk bucket turns them into a baby.
+# Changes the default /reply functionality.
+# If true, /reply will not check if the person you're replying to has vanished.
+# If false, players will not be able to /reply to players who they can no longer see due to vanish.
+last-message-reply-vanished: false
+
+# Toggles whether or not left clicking mobs with a milk bucket turns them into a baby.
 milk-bucket-easter-egg: true
 
 # Toggles whether or not the fly status message should be sent to players on join
@@ -449,8 +607,13 @@ npcs-in-balance-ranking: false
 # This is useful when a sign sells or buys one item at a time and the player wants to sell a bunch at once.
 allow-bulk-buy-sell: true
 
+# Allow selling of items with custom names with the /sell command.
+# This may be useful to prevent players accidentally selling named items.
+allow-selling-named-items: false
+
 # Delay for the MOTD display for players on join, in milliseconds.
 # This has no effect if the MOTD command or permission are disabled.
+# This can also be set to -1 to completely disable the join MOTD all together.
 delay-motd: 0
 
 # A list of commands that should have their complementary confirm commands enabled by default.
@@ -459,12 +622,23 @@ default-enabled-confirm-commands:
 #- pay
 #- clearinventory
 
-# Whether or not to teleport a player back to their previous position after they have been freed from jail.
-teleport-back-when-freed-from-jail: true
+# Where should Essentials teleport players when they are freed from jail?
+# You can set to "back" to have them teleported to where they were before they were jailed, "spawn" to have them
+# teleport to spawn, or "off" to not have them teleport.
+teleport-when-freed: back
+
+# Whether or not jail time should only be counted while the user is online.
+# If true, a jailed player's time will only decrement when they are online.
+jail-online-time: false
 
 # Set the timeout, in seconds for players to accept a tpa before the request is cancelled.
 # Set to 0 for no timeout.
 tpa-accept-cancellation: 120
+
+# The maximum number of simultaneous tpa requests that can be pending for any player.
+# Once past this threshold, old requests will instantly time out.
+# Defaults to 5.
+tpa-max-requests: 5
 
 # Allow players to set hats by clicking on their helmet slot.
 allow-direct-hat: true
@@ -474,6 +648,11 @@ allow-direct-hat: true
 # This doesn't affect running the command from the console, where a world is always required.
 allow-world-in-broadcastworld: true
 
+# Consider water blocks as "safe," therefore allowing players to teleport
+# using commands such as /home or /spawn to a location that is occupied
+# by water blocks
+is-water-safe: false
+
 # Should the usermap try to sanitise usernames before saving them?
 # You should only change this to false if you use Minecraft China.
 safe-usermap-names: true
@@ -482,17 +661,30 @@ safe-usermap-names: true
 # Example: CommandBlock at <x>,<y>,<z> issued server command: /<command>
 log-command-block-commands: false
 
+# Set the maximum speed for projectiles spawned with /fireball.
+max-projectile-speed: 8
+
+# Set the maximum amount of lore lines a user can set with the /itemlore command.
+# Users with the essentials.itemlore.bypass permission will be able to bypass this limit.
+max-itemlore-lines: 10
+
+# Should EssentialsX check for updates?
+# If set to true, EssentialsX will show notifications when a new version is available.
+# This uses the public GitHub API and no identifying information is sent or stored.
+update-check: false
+
 ############################################################
 # +------------------------------------------------------+ #
-# |                   EssentialsHome                     | #
+# |                        Homes                         | #
 # +------------------------------------------------------+ #
 ############################################################
 
-# Allows people to set their bed at daytime.
-update-bed-at-daytime: false
+# Allows people to set their bed during the day.
+# This setting has no effect in Minecraft 1.15+, as Minecraft will always allow the player to set their bed location during the day.
+update-bed-at-daytime: true
 
 # Set to true to enable per-world permissions for using homes to teleport between worlds.
-# This applies to the /home only.
+# This applies to the /home command only.
 # Give someone permission to teleport to a world with essentials.worlds.<worldname>
 world-home-permissions: false
 
@@ -516,22 +708,25 @@ sethome-multiple:
 # change the compass' direction to point towards their first home.
 compass-towards-home-perm: false
 
-# Set the maximum speed for projectiles spawned with /fireball.
-max-projectile-speed: 8
+# If no home is set, would you like to send the player to spawn?
+# If set to false, players will not be teleported when they run /home without setting a home first.
+spawn-if-no-home: true
+
+# Should players be asked to provide confirmation for homes which they attempt to overwrite?
+confirm-home-overwrite: false
 
 ############################################################
 # +------------------------------------------------------+ #
-# |                    EssentialsEco                     | #
+# |                       Economy                        | #
 # +------------------------------------------------------+ #
 ############################################################
 
 # For more information, visit http://wiki.ess3.net/wiki/Essentials_Economy
 
+# You can control the values of items that are sold to the server by using the /setworth command.
+
 # Defines the balance with which new players begin. Defaults to 0.
 starting-balance: 0
-
-# worth-# defines the value of an item when it is sold to the server via /sell.
-# These are now defined in worth.yml
 
 # Defines the cost to use the given commands PER USE.
 # Some commands like /repair have sub-costs, check the wiki for more information.
@@ -546,6 +741,10 @@ command-costs:
 # such as accented letters, you MUST save the file as UTF-8, not ANSI.
 currency-symbol: '$'
 
+# Enable this to make the currency symbol appear at the end of the amount rather than at the start.
+# For example, the euro symbol typically appears after the current amount.
+currency-symbol-suffix: false
+
 # Set the maximum amount of money a player can have.
 # The amount is always limited to 10 trillion because of the limitations of a java double.
 max-money: 10000000000000
@@ -557,8 +756,26 @@ min-money: -10000
 # Enable this to log all interactions with trade/buy/sell signs and sell command.
 economy-log-enabled: false
 
+# Enable this to also log all transactions from other plugins through Vault.
+# This can cause the economy log to fill up quickly so should only be enabled for testing purposes!
+economy-log-update-enabled: false
+
 # Minimum acceptable amount to be used in /pay.
 minimum-pay-amount: 0.001
+
+# Enable this to block users who try to /pay another user which ignore them.
+pay-excludes-ignore-list: false
+
+# Whether or not users with a balance less than or equal to $0 should be shown in balance-top.
+# Setting to false will not show people with balances <= 0 in balance-top.
+# NOTE: After reloading the config, you must also run '/baltop force' for this to appear
+show-zero-baltop: true
+
+# Requirements which must be met by the player to get their name shown in the balance top list.
+# Playtime is in seconds.
+baltop-requirements:
+  minimum-balance: 0
+  minimum-playtime: 0
 
 # The format of currency, excluding symbols. See currency-symbol-format-locale for symbol configuration.
 #
@@ -573,9 +790,18 @@ minimum-pay-amount: 0.001
 # For 1'234,50 use fr-ch
 #currency-symbol-format-locale: en-US
 
+# Allow players to receive multipliers for items sold with /sell or the sell sign.
+# You can set the default multiplier using the 'default' rank below.
+# To grant different multipliers to different people, you need to define a 'multiplier-rank' below.
+# Create the 'multiplier-rank' below, and give the matching permission: essentials.sell.multiplier.<multiplier-rank>
+sell-multipliers:
+  default: 1.0
+  double: 2.0
+  triple: 3.0
+
 ############################################################
 # +------------------------------------------------------+ #
-# |                   EssentialsHelp                     | #
+# |                         Help                         | #
 # +------------------------------------------------------+ #
 ############################################################
 
@@ -587,248 +813,5 @@ non-ess-in-help: true
 # The individual permission is: essentials.help.<plugin>, anyone with essentials.* or '*' will see all help regardless.
 # You can use negative permissions to remove access to just a single plugins help if the following is enabled.
 hide-permissionless-help: true
-
-############################################################
-# +------------------------------------------------------+ #
-# |                   EssentialsChat                     | #
-# +------------------------------------------------------+ #
-############################################################
-
-# This section requires the EssentialsChat.jar to work.
-
-chat:
-
-  # If EssentialsChat is installed, this will define how far a player's voice travels, in blocks.  Set to 0 to make all chat global.
-  # Note that users with the "essentials.chat.spy" permission will hear everything, regardless of this setting.
-  # Users with essentials.chat.shout can override this by prefixing text with an exclamation mark (!)
-  # Users with essentials.chat.question can override this by prefixing text with a question mark (?)
-  # You can add command costs for shout/question by adding chat-shout and chat-question to the command costs section."
-  radius: 0
-
-  # Chat formatting can be done in two ways, you can either define a standard format for all chat.
-  # Or you can give a group specific chat format, to give some extra variation.
-  # For more information of chat formatting, check out the wiki: http://wiki.ess3.net/wiki/Chat_Formatting
-  # For EssentialsX changes, take a look at the EssentialsX wiki: https://github.com/EssentialsX/Essentials/wiki
-
-  format: '<{DISPLAYNAME}> {MESSAGE}'
-  #format: '&7[{GROUP}]&r {DISPLAYNAME}&7:&r {MESSAGE}'
-  #format: '&7{PREFIX}&r {DISPLAYNAME}&r &7{SUFFIX}&r: {MESSAGE}'
-
-  group-formats:
-  #  Default: '{WORLDNAME} {DISPLAYNAME}&7:&r {MESSAGE}'
-  #  Admins: '{WORLDNAME} &c[{GROUP}]&r {DISPLAYNAME}&7:&c {MESSAGE}'
-
-  # If you are using group formats make sure to remove the '#' to allow the setting to be read.
-
-############################################################
-# +------------------------------------------------------+ #
-# |                 EssentialsProtect                    | #
-# +------------------------------------------------------+ #
-############################################################
-
-# This section requires the EssentialsProtect.jar to work.
-
-protect:
-
-  # General physics/behavior modifications.
-  prevent:
-    lava-flow: false
-    water-flow: false
-    water-bucket-flow: false
-    fire-spread: true
-    lava-fire-spread: true
-    flint-fire: false
-    lightning-fire-spread: true
-    portal-creation: false
-    tnt-explosion: false
-    tnt-playerdamage: false
-    tnt-minecart-explosion: false
-    tnt-minecart-playerdamage: false
-    fireball-explosion: false
-    fireball-fire: false
-    fireball-playerdamage: false
-    witherskull-explosion: false
-    witherskull-playerdamage: false
-    wither-spawnexplosion: false
-    wither-blockreplace: false
-    creeper-explosion: false
-    creeper-playerdamage: false
-    creeper-blockdamage: false
-    enderdragon-blockdamage: true
-    enderman-pickup: false
-    villager-death: false
-    # Monsters won't follow players.
-    # permission essentials.protect.entitytarget.bypass disables this.
-    entitytarget: false
-    # Prevent the spawning of creatures.
-    spawn:
-      creeper: false
-      skeleton: false
-      spider: false
-      giant: false
-      zombie: false
-      slime: false
-      ghast: false
-      pig_zombie: false
-      enderman: false
-      cave_spider: false
-      silverfish: false
-      blaze: false
-      magma_cube: false
-      ender_dragon: false
-      pig: false
-      sheep: false
-      cow: false
-      chicken: false
-      squid: false
-      wolf: false
-      mushroom_cow: false
-      snowman: false
-      ocelot: false
-      iron_golem: false
-      villager: false
-      wither: false
-      bat: false
-      witch: false
-      horse: false
-
-  # Maximum height the creeper should explode. -1 allows them to explode everywhere.
-  # Set prevent.creeper-explosion to true, if you want to disable creeper explosions.
-  creeper:
-    max-height: -1
-
-  # Disable various default physics and behaviors.
-  disable:
-    # Should fall damage be disabled?
-    fall: false
-
-    # Users with the essentials.protect.pvp permission will still be able to attack each other if this is set to true.
-    # They will be unable to attack users without that same permission node.
-    pvp: false
-
-    # Should drowning damage be disabled?
-    # (Split into two behaviors; generally, you want both set to the same value.)
-    drown: false
-    suffocate: false
-
-    # Should damage via lava be disabled?  Items that fall into lava will still burn to a crisp. ;)
-    lavadmg: false
-
-    # Should arrow damage be disabled?
-    projectiles: false
-
-    # This will disable damage from touching cacti.
-    contactdmg: false
-
-    # Burn, baby, burn!  Should fire damage be disabled?
-    firedmg: false
-
-    # Should the damage after hit by a lightning be disabled?
-    lightning: false
-
-    # Should Wither damage be disabled?
-    wither: false
-
-    # Disable weather options?
-    weather:
-      storm: false
-      thunder: false
-      lightning: false
-
-############################################################
-# +------------------------------------------------------+ #
-# |                EssentialsAntiBuild                   | #
-# +------------------------------------------------------+ #
-############################################################
-
-  # This section requires the EssentialsAntiBuild.jar to work.
-
-  # Disable various default physics and behaviors
-  # For more information, visit http://wiki.ess3.net/wiki/AntiBuild
-
-    # Should people with build: false in permissions be allowed to build?
-    # Set true to disable building for those people.
-    # Setting to false means EssentialsAntiBuild will never prevent you from building.
-    build: true
-
-    # Should people with build: false in permissions be allowed to use items?
-    # Set true to disable using for those people.
-    # Setting to false means EssentialsAntiBuild will never prevent you from using items.
-    use: true
-
-    # Should we tell people they are not allowed to build?
-    warn-on-build-disallow: true
-
-  # For which block types would you like to be alerted?
-  # You can find a list of items at https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html.
-  alert:
-    on-placement: LAVA,TNT,LAVA_BUCKET
-    on-use: LAVA_BUCKET
-    on-break:
-
-  blacklist:
-
-    # Which blocks should people be prevented from placing?
-    placement: LAVA,TNT,LAVA_BUCKET
-
-    # Which items should people be prevented from using?
-    usage: LAVA_BUCKET
-
-    # Which blocks should people be prevented from breaking?
-    break:
-
-    # Which blocks should not be pushed by pistons?
-    piston:
-
-    # Which blocks should not be dispensed by dispensers
-    dispenser:
-
-############################################################
-# +------------------------------------------------------+ #
-# |            Essentials Spawn / New Players            | #
-# +------------------------------------------------------+ #
-############################################################
-
-# This section requires essentialsspawn.jar to work.
-
-newbies:
-  # Should we announce to the server when someone logs in for the first time?
-  # If so, use this format, replacing {DISPLAYNAME} with the player name.
-  # If not, set to ''
-  #announce-format: ''
-  announce-format: '&dWelcome {DISPLAYNAME}&d to the server!'
-
-  # When we spawn for the first time, which spawnpoint do we use?
-  # Set to "none" if you want to use the spawn point of the world.
-  spawnpoint: newbies
-
-  # Do we want to give users anything on first join? Set to '' to disable
-  # This kit will be given regardless of cost and permissions, and will not trigger the kit delay.
-  #kit: ''
-  kit: tools
-
-# What priority should we use for handling respawns?
-# Set this to none, if you want vanilla respawning behaviour.
-# Set this to lowest, if you want Multiverse to handle the respawning.
-# Set this to high, if you want EssentialsSpawn to handle the respawning.
-# Set this to highest, if you want to force EssentialsSpawn to handle the respawning.
-respawn-listener-priority: high
-
-# What priority should we use for handling spawning on joining the server?
-# See respawn-listener-priority for possible values.
-# Note: changing this may impact or break spawn-on-join functionality.
-spawn-join-listener-priority: high
-
-# When users die, should they respawn at their first home or bed, instead of the spawnpoint?
-respawn-at-home: false
-
-# Teleport all joining players to the spawnpoint
-spawn-on-join: false
-# The following value of `guests` states that all players in group `guests` will be teleported to spawn when joining.
-#spawn-on-join: guests
-# The following list value states that all players in group `guests` and `admin` are to be teleported to spawn when joining. 
-#spawn-on-join:
-#- guests
-#- admin
 
 # End of file <-- No seriously, you're done with configuration.

--- a/plugins/Essentials/tpr.yml
+++ b/plugins/Essentials/tpr.yml
@@ -1,5 +1,6 @@
 # Configuration for the random teleport command.
-# Some settings may be defaulted, and can be changed via the /settpr command in-game.
+# Use the /settpr command in-game to set random teleport locations.
+
 min-range: 0.0
 excluded-biomes:
 - cold_ocean

--- a/plugins/Essentials/upgrades-done.yml
+++ b/plugins/Essentials/upgrades-done.yml
@@ -17,3 +17,4 @@ updateUsersMailList: true
 updatePurgeBrokenNpcAccounts: true
 newUidCacheBuilt: true
 updateLegacyToAdventure: true
+updateRandomTeleport: true

--- a/plugins/FastAsyncWorldEdit/config.yml
+++ b/plugins/FastAsyncWorldEdit/config.yml
@@ -1,9 +1,9 @@
 # These first 6 aren't configurable
 issues: "https://github.com/IntellectualSites/FastAsyncWorldEdit/issues"
 wiki: "https://intellectualsites.github.io/fastasyncworldedit-documentation/"
-date: "Sat Jul 20 00:00:00 UTC 2024"
-build: "https://ci.athion.net/job/FastAsyncWorldEdit/812"
-commit: "https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/f2962369"
+date: "Fri Jan 17 00:00:00 GMT-03:00 2025"
+build: "https://ci.athion.net/job/FastAsyncWorldEdit/997"
+commit: "https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/f8b4491d"
 platform: "Bukkit"
 # Set true to enable WorldEdit restrictions per region (e.g. PlotSquared or WorldGuard).
 # To be allowed to WorldEdit in a region, users need the appropriate
@@ -111,6 +111,11 @@ extent:
 #  - UNSAFE = Can cause permanent damage to the server
 #  - SAFE = Can be buggy but unlikely to cause any damage
 experimental:
+  # Undo operation batch size
+  #  - The size defines the number of changes read at once.
+  #  - Larger numbers might reduce overhead but increase latency for edits with only few changes.
+  #  - 0 means undo operations are not batched.
+  undo-batch-size: 128
   # [UNSAFE] Directly modify the region files. (OBSOLETE - USE ANVIL COMMANDS)
   #  - IMPROPER USE CAN CAUSE WORLD CORRUPTION!
   anvil-queue-mode: false
@@ -138,6 +143,8 @@ experimental:
   # This has no effect on existing blocks one way or the other.
   # Changes due to fluid flow will not be tracked by history, thus may have unintended consequences
   allow-tick-fluids: false
+  # Whether FAWE should use the incubator Vector API to accelerate some operations
+  use-vector-api: false
 
 # This relates to how FAWE places chunks
 queue:
@@ -220,6 +227,8 @@ history:
   delete-after-days: 1
   # Delete history in memory on logout (does not effect disk)
   delete-on-logout: true
+  # Delete history on disk on logout
+  delete-disk-on-logout: true
   # If history should be enabled by default for plugins using WorldEdit:
   #  - It is faster to have disabled
   #  - It is faster to have disabled
@@ -346,6 +355,8 @@ limits:
     #  - Can prevent blocks being pasted from clipboards, etc.
     #  - If fast-placement is disabled, this may cause edits to be slower.
     universal-disallowed-blocks: true
+    # If legacy, mumerical, blocks IDs should be able to be used (i.e. 12:2),
+    allow-legacy: true
     # List of blocks to deny use of. Can be either an entire block type or a block with a specific property value.
     # Where block properties are specified, any blockstate with the property will be disallowed (e.g. all directions
     # of a waterlogged fence). For blocking/remapping of all occurrences of a property like waterlogged, see

--- a/plugins/Geyser-Spigot/config.yml
+++ b/plugins/Geyser-Spigot/config.yml
@@ -19,8 +19,8 @@ bedrock:
   clone-remote-port: false
   # The MOTD that will be broadcasted to Minecraft: Bedrock Edition clients. Irrelevant if "passthrough-motd" is set to true
   # If either of these are empty, the respective string will default to "Geyser"
-  motd1: "§7§lKaboom > §rFree OP - Anarchy"
-  motd2: "§7§lKaboom > §rFree OP - Anarchy"
+  motd1: "§fFree OP - Anarchy"
+  motd2: "§8§lWelcome to Kaboom!"
   # The Server Name that will be sent to Minecraft: Bedrock Edition clients. This is visible in both the pause menu and the settings menu.
   server-name: "Kaboom"
   # Whether to enable PROXY protocol or not for clients. You DO NOT WANT this feature unless you run UDP reverse proxy
@@ -43,7 +43,7 @@ remote:
   auth-type: offline
   # Allow for password-based authentication methods through Geyser. Only useful in online mode.
   # If this is false, users must authenticate to Microsoft using a code provided by Geyser on their desktop.
-  allow-password-authentication: true
+  allow-password-authentication: false
   # Whether to enable PROXY protocol or not while connecting to the server.
   # This is useful only when:
   # 1) Your server supports PROXY protocol (it probably doesn't)
@@ -105,11 +105,11 @@ general-thread-pool: 32
 
 # Allow third party capes to be visible. Currently allowing:
 # OptiFine capes, LabyMod capes, 5Zig capes and MinecraftCapes
-allow-third-party-capes: true
+allow-third-party-capes: false
 
 # Allow third party deadmau5 ears to be visible. Currently allowing:
 # MinecraftCapes
-allow-third-party-ears: true
+allow-third-party-ears: false
 
 # Allow a fake cooldown indicator to be sent. Bedrock players do not see a cooldown as they still use 1.8 combat
 show-cooldown: true

--- a/plugins/ViaBackwards/config.yml
+++ b/plugins/ViaBackwards/config.yml
@@ -21,5 +21,18 @@ fix-formatted-inventory-titles: true
 # This only takes effect for ids in the short range. Useful for anticheat compatibility.
 handle-pings-as-inv-acknowledgements: false
 #
+# Adds bedrock blocks at y=0 for sub 1.17 clients. This may allow for weird interactions due to sending fake blocks.
+bedrock-at-y-0: false
+#
+# Shows sculk shriekers as crying obsidian for 1.18.2 clients on 1.19+ servers. This fixes collision and block breaking issues.
+# If disabled, the client will see them as end portal frames.
+sculk-shriekers-to-crying-obsidian: true
+#
+# Maps the darkness effect to blindness for 1.18.2 clients on 1.19+ servers.
+map-darkness-effect: true
+#
+# If enabled, 1.21.3 clients will receive the first float of 1.21.4+ custom model data as int. Disable if you handle this change yourself.
+map-custom-model-data: true
+#
 # Suppresses warnings of missing emulations for certain features that are not supported (e.g. world height in 1.17+).
-suppress-emulation-warnings: false
+suppress-emulation-warnings: true

--- a/plugins/ViaRewind/config.yml
+++ b/plugins/ViaRewind/config.yml
@@ -3,7 +3,8 @@
 # Specifies how 1.8.x clients should see the cooldown indicator
 # You can choose between TITLE, ACTION_BAR, BOSS_BAR and DISABLED
 # ONLY DISABLE IF YOU HAVE 1.9 COOLDOWN DISABLED ON YOUR SERVER
-# 1.8 PLAYERS MAY ASK WHY PVP IS NOT WORKING OTHERWISE
+# 1.8 PLAYERS MAY ASK WHY PVP IS NOT WORKING OTHERWISE.
+# REQUIRES A SERVER RESTART TO TAKE EFFECT
 cooldown-indicator: TITLE
 #
 # Replaces Adventure mode with Survival mode for 1.7.x clients
@@ -11,14 +12,14 @@ cooldown-indicator: TITLE
 # or 'CanPlaceOn' flags on items
 replace-adventure: false
 #
-# Whether 1.9 particles should be replaced by similar ones in
+# Whether similar ones should replace 1.9 particles in
 # 1.8 and lower
 replace-particles: false
 #
-# Max amount of pages for written books before a client gets kicked
+# Max number of pages for written books before a client gets kicked
 max-book-pages: 100
 #
-# Max amount of characters in the json (!) string of a book page before a client gets kicked
+# Max number of characters in the json (!) string of a book page before a client gets kicked
 max-book-page-length: 5000
 #
 # Whether to emulate the 1.8+ world border for 1.7.x clients
@@ -28,11 +29,16 @@ emulate-world-border: true
 always-show-original-mob-name: true
 #
 # The particle to show the world border for the 1.8+ world border for 1.7.x clients
-# see https://wiki.vg/index.php?title=Protocol&oldid=7368#Particle_2
 world-border-particle: fireworksSpark
 #
 # If enabled, 1.8 players on 1.9+ servers can use /offhand to switch items between their main hand and offhand.
 enable-offhand: true
 #
-# Allows to define the offhand command
+# Allows defining the offhand command
 offhand-command: /offhand
+#
+# If enabled, 1.8 players on 1.9+ servers will also experience the levitation effect by sending velocity packets.
+emulate-levitation-effect: true
+#
+# If enabled, 1.8 players will handle the player combat packet added in 1.9 by showing the custom death message above the hotbar.
+handle-player-combat-packet: true

--- a/plugins/ViaVersion/config.yml
+++ b/plugins/ViaVersion/config.yml
@@ -17,7 +17,7 @@ send-supported-versions: false
 # You can use both this and the block-protocols option at the same time as well.
 block-versions: []
 # Block specific Minecraft protocol version numbers.
-# List of all Minecraft protocol versions: https://wiki.vg/Protocol_version_numbers, or use a generator: https://via.krusic22.com
+# List of all Minecraft protocol versions: https://minecraft.wiki/w/Protocol_version, or use a generator: https://via.krusic22.com
 block-protocols: []
 # Change the blocked disconnect message
 block-disconnect-msg: You are using an unsupported Minecraft version!
@@ -25,7 +25,7 @@ block-disconnect-msg: You are using an unsupported Minecraft version!
 # (We don't suggest using reload either, use a plugin manager)
 # You can customize the message we kick people with if you use ProtocolLib here.
 reload-disconnect-msg: Server reload, please rejoin!
-# We warn when there's an error converting item and block data over versions, should we suppress these? (Only suggested if spamming)
+# We warn when there's an error converting item/block or component/nbt data over versions, should we suppress these? (Only suggested if spamming)
 suppress-conversion-warnings: true
 #
 #----------------------------------------------------------#
@@ -142,6 +142,12 @@ enforce-secure-chat: false
 # Handles items with invalid count values (higher than max stack size) on 1.20.3 servers.
 handle-invalid-item-count: false
 #
+# Hides scoreboard numbers for 1.20.3+ clients on older server versions.
+hide-scoreboard-numbers: false
+#
+# Fixes 1.21+ clients on 1.20.5 servers placing water/lava buckets at the wrong location when moving fast, NOTE: This may cause issues with anti-cheat plugins.
+fix-1_21-placement-rotation: true
+#
 #----------------------------------------------------------#
 #             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#
@@ -151,7 +157,7 @@ handle-invalid-item-count: false
 prevent-collision: false
 # If the above is true, should we automatically team players until you do?
 auto-team: false
-# When enabled if certain metadata can't be read, we won't tell you about it
+# When enabled if certain entity data can't be read, we won't tell you about it
 suppress-metadata-errors: true
 # When enabled, 1.9+ will be able to block by using shields
 shield-blocking: false
@@ -183,7 +189,7 @@ replace-pistons: false
 replacement-piston-id: 0
 # Fix 1.9+ clients not rendering the far away chunks and improve chunk rendering when moving fast (Increases network usage and decreases client fps slightly)
 chunk-border-fix: false
-# Minimize the cooldown animation in 1.8 servers
-minimize-cooldown: false
 # Allows 1.9+ left-handedness (main hand) on 1.8 servers
 left-handed-handling: false
+# Tries to cancel block break/place sounds sent by 1.8 servers to 1.9+ clients to prevent them from playing twice
+cancel-block-sounds: true

--- a/spigot.yml
+++ b/spigot.yml
@@ -63,6 +63,7 @@ advancements:
   - '*'
 world-settings:
   default:
+    seed-trialchambers: 94251327
     below-zero-generation-in-existing-chunks: true
     simulation-distance: default
     thunder-chance: 100000


### PR DESCRIPTION
Syncs the server's config files with the defaults for the plugins.
Originally, I was going to have all of this in my 1.21.4 PR but I decided to not do that because the Essentials changes were particularly large.

Minor changes:
- The Geyser motd has been changed so that it fits in Bedrock's server list
- Geyser's third party integrations are now disabled, since they were removed (having them enabled results in WARN logs)
- ViaBackwards's suppress-emulation-warnings is now true (so that players connecting on old versions don't cause console spam)

Other than that, there shouldn't be any user-facing changes.