### PR TITLE
Disable spawner ticking

### DIFF
--- a/config/paper-world-defaults.yml
+++ b/config/paper-world-defaults.yml
@@ -307,7 +307,7 @@ tick-rates:
   container-update: 1
   dry-farmland: 1
   grass-spread: 1
-  mob-spawner: 1
+  mob-spawner: -1
   sensor:
     villager:
       secondarypoisensor: 40


### PR DESCRIPTION
For the past few weeks, the server has been constantly made unplayable by people with a spawner that makes the server just laggy enough to the point where players aren't able to do anything, but still "fast" enough where it replies to the alivechecker's pings in time.

Since there isn't really a proper fix, as currently spawners can only be limited through plugins, which can't fully block them (they tick once before PreSpawnerSpawnEvent), I think completely blocking spawners is a good temporary solution.

Closes #126