### PR TITLE
Migrate old FAWE update ignore config to new one

### DIFF
--- a/plugins/FastAsyncWorldEdit/config.yml
+++ b/plugins/FastAsyncWorldEdit/config.yml
@@ -20,8 +20,12 @@ enabled-components:
   # Show additional information in console. It helps us at IntellectualSites to find out more about an issue.
   # Leave it off if you don't need it, it can spam your console.
   debug: false
-  # Whether or not FAWE should notify you on startup about new versions available.
-  update-notifications: false
+  # Whether or not FAWE should notify you on startup about new available snapshots.
+  snapshot-update-notifications: false
+  # Whether or not FAWE should notify you on startup about new releases.
+  release-update-notifications: false
+  # Whether or not FAWE should notify you for updates (snapshot / release) on join (with the required permission)
+  notify-update-ingame: false
 
 clipboard:
   # Store the clipboard on disk instead of memory


### PR DESCRIPTION
Not sure why FAWE doesn't migrate this for us...