### PR TITLE
Allow non-player entities in teams

### DIFF
--- a/config/paper-world-defaults.yml
+++ b/config/paper-world-defaults.yml
@@ -301,7 +301,7 @@ misc:
   show-sign-click-command-failure-msgs-to-player: true
   update-pathfinding-on-block-update: false
 scoreboards:
-  allow-non-player-entities-on-scoreboards: false
+  allow-non-player-entities-on-scoreboards: true
   use-vanilla-world-scoreboard-name-coloring: false
 spawn:
   allow-using-signs-inside-spawn-protection: false


### PR DESCRIPTION
Not sure why this was disabled, but it's pretty annoying to not be able to disable the collision of non-player entities