### PR TITLE
1.21.6

### DIFF
--- a/commands.yml
+++ b/commands.yml
@@ -179,4 +179,8 @@ aliases:
   - []
   minecraft:datapack:
   - []
+  test:
+  - []
+  minecraft:test:
+  - []
 unrestricted-advancements: false

--- a/commands.yml
+++ b/commands.yml
@@ -183,4 +183,8 @@ aliases:
   - []
   minecraft:test:
   - []
+  dialog:
+  - []
+  minecraft:dialog:
+  - []
 unrestricted-advancements: false

--- a/scripts/downloads.json
+++ b/scripts/downloads.json
@@ -47,7 +47,7 @@
             "mods/PaperMixins.jar": {
                 "type": "zip",
                 "skip_404": true,
-                "url":  "https://nightly.link/kaboomserver/papermixins/workflows/build/master/Artifacts.zip",
+                "url": "https://nightly.link/kaboomserver/papermixins/workflows/build/1.21.7/Artifacts.zip",
                 "extract": "paper-mixins-master.jar"
             },
             "plugins/CommandSpy.jar": {

--- a/scripts/downloads.json
+++ b/scripts/downloads.json
@@ -8,7 +8,7 @@
         "type": "bibliothek",
         "endpoint": "https://api.papermc.io",
         "project": "paper",
-        "version": "1.21.4"
+        "version": "1.21.7"
     },
     "plugins": {
         "external": {


### PR DESCRIPTION
Test server: `amy.lat`

- [x] Fix username validation disabling 

Players with section signs in their usernames now cause the server to crash. Yay Mojang!

- [x] Decide what to do with Minecraft's Test system

Should the `/test` command be blocked or heavily restricted? (`/test verify` lags the server; some other sub-commands freeze the server for a bit)
Test Block: Maybe clear the message on Log mode after it's powered to prevent log spam

- [x] Fix `/fill` with automatic command blocks (https://github.com/kaboomserver/papermixins/pull/16)

SNBT changes made this incredibly easy to bypass: `/fill ~ ~ ~ ~ ~ ~ minecraft:command_block{ "\u0061uto":1b }`
This entire check should probably be moved to Paper Mixins so that /filled or /cloned command blocks have their commands cleared