### PR TITLE
refactor: cleanup FAWE permissions

### DIFF
--- a/permissions.yml
+++ b/permissions.yml
@@ -33,202 +33,67 @@ op:
 
       essentials.nick.allowunsafe: true
 
-      # Due to WorldEdit permission shenanigans, we have to grant
-      # permissions manually to enforce block edit limits
-
       # //hmi (broken); update alerts (disabled) and //wea (bypasses limits)
       fawe.admin: false
       fawe.bypass: false
       fawe.bypass.regions: false
 
-      fawe.worldeditregion: true
-      fawe.cancel: true
+      # FAWE does not grant all permissions to OPs by default, so we have to
+      # do this to give players access to the full set of WorldEdit commands.
       fawe.setupdispatcher: true
-      fawe.tips: true
       worldedit.anyblock: true
-      worldedit.biome.info: true
-      worldedit.biome.set: true
-      worldedit.biome.list: true
-      worldedit.chunkinfo: true
-      worldedit.listchunks: true
-      worldedit.clipboard.cut: true
-      worldedit.clipboard.paste: true
-      worldedit.schematic.formats: true
-      worldedit.schematic.load: true
-      worldedit.schematic.load.asset: true
-      worldedit.schematic.load.web: true
-      worldedit.schematic.list: true
-      worldedit.schematic.remap: true
-      worldedit.schematic.save: true
-      worldedit.clipboard.asset: true
-      worldedit.clipboard.clear: true
-      worldedit.clipboard.copy: true
-      worldedit.clipboard.lazycopy: true
-      worldedit.clipboard.lazycut: true
-      worldedit.clipboard.place: true
-      worldedit.clipboard.download: true
-      worldedit.clipboard.flip: true
-      worldedit.clipboard.rotate: true
-      worldedit.help: true
-      worldedit.global-mask: true
-      worldedit.global-transform: true
-      worldedit.generation.cylinder: true
-      worldedit.generation.sphere: true
-      worldedit.generation.forest: true
-      worldedit.generation.image: true
-      worldedit.generation.ore: true
-      worldedit.generation.pumpkins: true
-      worldedit.generation.pyramid: true
-      worldedit.generation.shape: true
-      worldedit.generation.shape.biome: true
-      worldedit.history.clear: true
-      worldedit.history.undo: true
-      worldedit.history.redo: true
-      worldedit.history.rollback: true
-      worldedit.navigation.unstuck: true
-      worldedit.navigation.ascend: true
-      worldedit.navigation.descend: true
-      worldedit.navigation.ceiling: true
-      worldedit.navigation.thru.command: true
-      worldedit.navigation.jumpto.command: true
-      worldedit.navigation.up: true
-      worldedit.nbtinfo: true
-      worldedit.region.hollow: true
-      worldedit.region.line: true
-      worldedit.region.curve: true
-      worldedit.region.overlay: true
-      worldedit.region.center: true
-      worldedit.region.naturalize: true
-      worldedit.region.walls: true
-      worldedit.region.faces: true
-      worldedit.region.fall: true
-      worldedit.region.flora: true
-      worldedit.region.smooth: true
-      worldedit.region.deform: true
-      worldedit.region.move: true
-      worldedit.region.forest: true
-      worldedit.region.replace: true
-      worldedit.region.stack: true
-      worldedit.region.set: true
-      worldedit.selection.pos: true
-      worldedit.selection.chunk: true
-      worldedit.selection.hpos: true
-      worldedit.wand: true
-      worldedit.wand.toggle: true
-      worldedit.selection.contract: true
-      worldedit.selection.outset: true
-      worldedit.selection.inset: true
-      worldedit.analysis.distr: true
-      worldedit.analysis.count: true
-      worldedit.analysis.sel: true
-      worldedit.selection.size: true
-      worldedit.selection.expand: true
-      worldedit.selection.shift: true
-      worldedit.snapshots.list: true
-      worldedit.snapshots.restore: true
-      worldedit.superpickaxe: true
-      worldedit.superpickaxe.area: true
-      worldedit.superpickaxe.recursive: true
-      worldedit.brush.blendball: true
       worldedit.brush.butcher: true
       worldedit.brush.deform: true
-      worldedit.brush.erode: true
       worldedit.brush.forest: true
-      worldedit.brush.pull: true
-      worldedit.brush.circle: true
-      worldedit.brush.recursive: true
-      worldedit.brush.line: true
       worldedit.brush.list: true
       worldedit.brush.load: true
       worldedit.brush.lower: true
+      worldedit.brush.options.tracemask: true
       worldedit.brush.paint: true
       worldedit.brush.primary: true
       worldedit.brush.raise: true
       worldedit.brush.scroll: true
       worldedit.brush.secondary: true
       worldedit.brush.set: true
-      worldedit.brush.spline: true
       worldedit.brush.surface: true
-      worldedit.brush.surfacespline: true
       worldedit.brush.sweep: true
-      worldedit.brush.shatter: true
-      worldedit.brush.stencil: true
-      worldedit.brush.target: true
       worldedit.brush.targetmask: true
       worldedit.brush.targetoffset: true
+      worldedit.brush.target: true
       worldedit.brush.visualize: true
-      worldedit.brush.height: true
-      worldedit.brush.layer: true
-      worldedit.brush.populateschematic: true
-      worldedit.brush.scatter: true
-      worldedit.brush.splatter: true
-      worldedit.brush.scattercommand: true
-      worldedit.brush.copy: true
-      worldedit.brush.command: true
-      worldedit.brush.apply: true
-      worldedit.brush.sphere: true
-      worldedit.brush.cylinder: true
-      worldedit.brush.clipboard: true
-      worldedit.brush.smooth: true
-      worldedit.brush.ex: true
-      worldedit.brush.gravity: true
-      worldedit.brush.options.range: true
-      worldedit.brush.options.material: true
-      worldedit.brush.options.size: true
-      worldedit.brush.options.mask: true
-      worldedit.brush.options.smask: true
-      worldedit.brush.options.transform: true
-      worldedit.brush.options.scroll: true
-      worldedit.brush.options.visualize: true
-      worldedit.brush.options.tracemask: true
-      worldedit.tool.deltree: true
-      worldedit.tool.farwand: true
-      worldedit.tool.lrbuild: true
-      worldedit.tool.info: true
-      worldedit.tool.tree: true
-      worldedit.tool.replacer: true
-      worldedit.tool.data-cycler: true
-      worldedit.tool.flood-fill: true
-      worldedit.tool.inspect: true
-      worldedit.tool.none: true
+      worldedit.butcher: true
+      worldedit.clipboard.asset: true
+      worldedit.clipboard.lazycut: true
+      worldedit.clipboard.load: true
+      worldedit.clipboard.save: true
+      worldedit.debugpaste: true
+      worldedit.drawsel: true
+      worldedit.fast: true
+      worldedit.generation.image: true
+      worldedit.generation.ore: true
+      worldedit.generation.shape.biome: true
+      worldedit.global-texture: true
+      worldedit.history.clear: true
       worldedit.light.fix: true
       worldedit.light.remove: true
       worldedit.light.set: true
-      worldedit.fill.recursive: true
-      worldedit.scripting.execute: true
-      worldedit.drain: true
-      worldedit.fixlava: true
-      worldedit.fixwater: true
-      worldedit.removeabove: true
-      worldedit.removebelow: true
-      worldedit.removenear: true
-      worldedit.replacenear: true
-      worldedit.snow: true
-      worldedit.thaw: true
-      worldedit.green: true
-      worldedit.extinguish: true
-      worldedit.calc: true
-      worldedit.fill: true
-      worldedit.searchitem: true
-      worldedit.global-texture: true
-      worldedit.butcher: true
-      worldedit.drawsel: true
-      worldedit.debugpaste: true
-      worldedit.fast: true
       worldedit.masks: true
+      worldedit.nbtinfo: true
       worldedit.patterns: true
+      worldedit.region.deform: true
+      worldedit.region.fall: true
+      worldedit.region.flora: true
       worldedit.remove: true
-      worldedit.threads: true
-      worldedit.transforms: true
-      worldedit.toggleplace: true
-      worldedit.setwand: true
-      worldedit.clipboard.save: true
-      worldedit.schematic.delete: true
-      worldedit.schematic.move: true
-      worldedit.schematic.move.other: true
-      worldedit.clipboard.load: true
+      worldedit.schematic.load.asset: true
       worldedit.schematic.load.other: true
+      worldedit.schematic.load.web: true
+      worldedit.schematic.remap: true
       worldedit.schematic.save.other: true
+      worldedit.searchitem: true
+      worldedit.setwand: true
+      worldedit.threads: true
+      worldedit.toggleplace: true
+      worldedit.transforms: true
 
 deop:
   default: not-op


### PR DESCRIPTION
I organized every permission alphabetically, so the diffs look horrible on this one. Sorry.
See https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/main/worldedit-bukkit/src/main/resources/plugin.yml for a list of permissions that FAWE grants by default

I also removed some other permissions that didn't make sense on the server: schematic deleting/moving, CraftScript execution (was already disabled) and snapshot restoring (was already disabled).