### PR TITLE
Disable block interaction limit

### DIFF
--- a/config/paper-global.yml
+++ b/config/paper-global.yml
@@ -129,7 +129,7 @@ scoreboards:
   save-empty-scoreboard-teams: false
   track-plugin-scoreboards: false
 spam-limiter:
-  incoming-packet-threshold: 300
+  incoming-packet-threshold: -1
   recipe-spam-increment: 1
   recipe-spam-limit: 20
   tab-spam-increment: 1


### PR DESCRIPTION
Despite the confusing name of the config option, this value is only used for limiting entity & block interactions.
I don't think this really makes sense for a creative free-op server, as this interferes with fast modes of schematic printers (which allowing may make people think twice spamming cspy with /fill and /setblock).