### PR TITLE
1.21.9

### DIFF
--- a/config/paper-global.yml
+++ b/config/paper-global.yml
@@ -13,7 +13,7 @@
 # Discord: https://discord.gg/papermc
 # Website: https://papermc.io/
 
-_version: 30
+_version: 31
 anticheat:
   obfuscation:
     items:
@@ -43,7 +43,6 @@ chunk-loading-basic:
   player-max-chunk-load-rate: 100.0
   player-max-chunk-send-rate: 75.0
 chunk-system:
-  gen-parallelism: enabled
   io-threads: -1
   worker-threads: -1
 collisions:
@@ -85,6 +84,7 @@ misc:
     chat-executor-max-size: -1
   client-interaction-leniency-distance: default
   compression-level: default
+  enable-nether: true
   lag-compensate-block-breaking: true
   load-permissions-yml-before-plugins: false
   max-joins-per-tick: 5

--- a/config/paper-world-defaults.yml
+++ b/config/paper-world-defaults.yml
@@ -124,6 +124,7 @@ entities:
     player-insomnia-start-ticks: 72000
     should-remove-dragon: false
     spawner-nerfed-mobs-should-jump: false
+    stuck-entity-poi-retry-delay: 200
     zombie-villager-infection-chance: default
     zombies-target-turtle-eggs: false
   markers:
@@ -291,6 +292,7 @@ max-growth-height:
   cactus: 3
   reeds: 3
 misc:
+  allow-remote-ender-dragon-respawning: false
   alternate-current-update-order: HORIZONTAL_FIRST_OUTWARD
   disable-end-credits: true
   disable-relative-projectile-velocity: false
@@ -298,7 +300,6 @@ misc:
   legacy-ender-pearl-behavior: false
   max-leash-distance: 10.0
   redstone-implementation: ALTERNATE_CURRENT
-  shield-blocking-delay: 5
   show-sign-click-command-failure-msgs-to-player: true
   update-pathfinding-on-block-update: false
 scoreboards:
@@ -306,8 +307,6 @@ scoreboards:
   use-vanilla-world-scoreboard-name-coloring: false
 spawn:
   allow-using-signs-inside-spawn-protection: false
-  keep-spawn-loaded: false
-  keep-spawn-loaded-range: 10
 tick-rates:
   behavior:
     villager:

--- a/scripts/downloads.json
+++ b/scripts/downloads.json
@@ -8,7 +8,7 @@
         "type": "fill",
         "endpoint": "https://fill.papermc.io",
         "project": "paper",
-        "version": "1.21.8"
+        "version": "1.21.9"
     },
     "plugins": {
         "external": {
@@ -24,7 +24,7 @@
             },
             "plugins/Geyser.jar": {
                 "type": "zip",
-                "url": "https://nightly.link/GeyserMC/Geyser/workflows/build/master/Geyser-Spigot.zip",
+                "url": "https://nightly.link/GeyserMC/Geyser/workflows/build/feature%2F1.21.9/Geyser-Spigot.zip",
                 "extract": "Geyser-Spigot.jar"
             },
             "plugins/ViaVersion.jar": {
@@ -47,7 +47,7 @@
             "mods/PaperMixins.jar": {
                 "type": "zip",
                 "skip_404": true,
-                "url": "https://nightly.link/kaboomserver/papermixins/workflows/build/1.21.7/Artifacts.zip",
+                "url": "https://nightly.link/kaboomserver/papermixins/workflows/build/1.21.9/Artifacts.zip",
                 "extract": "paper-mixins-master.jar"
             },
             "plugins/CommandSpy.jar": {
@@ -59,7 +59,7 @@
             "plugins/Extras.jar": {
                 "type": "zip",
                 "skip_404": true,
-                "url": "https://nightly.link/kaboomserver/extras/workflows/main/master/Extras.zip",
+                "url": "https://nightly.link/kaboomserver/extras/actions/runs/18145392580/Extras.zip",
                 "extract": "Extras.jar"
             },
             "plugins/iControlU.jar": {

--- a/server.properties
+++ b/server.properties
@@ -1,14 +1,13 @@
 #Minecraft server properties
-#Wed Jan 29 00:00:00 UTC 2025
+#Wed Sep 31 00:00:00 UTC 2025
 accepts-transfers=true
 allow-flight=true
-allow-nether=true
 broadcast-console-to-ops=true
 broadcast-rcon-to-ops=true
 bug-report-link=
 debug=false
 difficulty=easy
-enable-command-block=true
+enable-code-of-conduct=false
 enable-jmx-monitoring=false
 enable-query=true
 enable-rcon=false
@@ -29,6 +28,7 @@ level-name=world
 level-seed=
 level-type=minecraft\:normal
 log-ips=true
+management-server-enabled=false
 max-chained-neighbor-updates=500
 max-players=0
 max-tick-time=30000
@@ -40,7 +40,6 @@ op-permission-level=4
 pause-when-empty-seconds=60
 player-idle-timeout=0
 prevent-proxy-connections=false
-pvp=true
 query.port=25565
 rate-limit=0
 rcon.password=
@@ -54,10 +53,8 @@ resource-pack-sha1=
 server-ip=
 server-port=25565
 simulation-distance=5
-spawn-animals=true
-spawn-monsters=true
-spawn-npcs=true
 spawn-protection=0
+status-heartbeat-interval=0
 sync-chunk-writes=false
 text-filtering-config=
 text-filtering-version=0


### PR DESCRIPTION
Blocked on:
- [ ] FAWE, Geyser and ViaVersion builds for 1.21.9 
- [ ] Paper 1.21.9 becoming stable
- [ ] https://github.com/kaboomserver/extras/pull/387 (mostly)