### PR TITLE
26.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 cache/
+/.paper/
 /libraries/
 /logs/
-/plugins/.paper-remapped/
 /plugins/CommandSpy/state.bin
 /plugins/Essentials/userdata
 /plugins/Essentials/warps/*
@@ -11,16 +11,14 @@ cache/
 /plugins/Essentials/usermap.bin
 /plugins/Essentials/uuids.bin
 /plugins/Essentials/worth.yml
+/plugins/Extras/prefixes.yml
 /plugins/FastAsyncWorldEdit/lang/
 /plugins/Geyser-Spigot/locales/
 /plugins/spark/tmp/
-/.console_history
 /versions/
 /worlds/
 /banned-ips.json
 /banned-players.json
-/help.yml
 /ops.json
 /usercache.json
-/version_history.json
 /whitelist.json

--- a/config/paper-global.yml
+++ b/config/paper-global.yml
@@ -76,6 +76,7 @@ messages:
     Please contact the server administrators if you believe that this is in error.
   use-display-name-in-quit-message: false
 misc:
+  catchup-ticks: default
   chat-threads:
     chat-executor-core-size: -1
     chat-executor-max-size: -1

--- a/plugins/FastAsyncWorldEdit/config.yml
+++ b/plugins/FastAsyncWorldEdit/config.yml
@@ -1,9 +1,9 @@
 # These first 6 aren't configurable
 issues: "https://github.com/IntellectualSites/FastAsyncWorldEdit/issues"
 wiki: "https://intellectualsites.github.io/fastasyncworldedit-documentation/"
-date: "Mon Mar 16 00:00:00 GMT-03:00 2026"
-build: "https://ci.athion.net/job/FastAsyncWorldEdit/1277"
-commit: "https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/f7fced39"
+date: "Sat Aug 08 00:00:00 GMT-03:00 2026"
+build: "https://ci.athion.net/job/FastAsyncWorldEdit/1348"
+commit: "https://github.com/IntellectualSites/FastAsyncWorldEdit/commit/f4697da2"
 platform: "Bukkit"
 # Set true to enable WorldEdit restrictions per region (e.g. PlotSquared or WorldGuard).
 # To be allowed to WorldEdit in a region, users need the appropriate

--- a/plugins/ViaVersion/config.yml
+++ b/plugins/ViaVersion/config.yml
@@ -102,6 +102,8 @@ register-userconnections-on-join: true
 piston-animation-patch: false
 # Experimental - Should we fix shift quick move action for 1.12 clients (causes shift + double click not to work when moving items) (only works on 1.8-1.11.2 bukkit based servers)
 quick-move-action-fix: false
+# Should we fix the client-randomized reddust color for 1.13+ clients? This will result in an extra packet per count, so enabling this may spam clients.
+multi-reddust-color-fix: false
 # Should we use prefix for team color on 1.13 and above clients?
 team-colour-fix: false
 # 1.13 introduced new auto complete which can trigger "Kicked for spamming" for servers older than 1.13, the following option will disable it completely.

--- a/scripts/downloads.json
+++ b/scripts/downloads.json
@@ -8,7 +8,7 @@
         "type": "fill",
         "endpoint": "https://fill.papermc.io",
         "project": "paper",
-        "version": "26.1.2"
+        "version": "26.2"
     },
     "plugins": {
         "external": {
@@ -46,7 +46,7 @@
             "mods/PaperMixins.jar": {
                 "type": "zip",
                 "skip_404": true,
-                "url": "https://nightly.link/kaboomserver/papermixins/workflows/build/26.1/Artifacts.zip",
+                "url": "https://nightly.link/kaboomserver/papermixins/workflows/build/26.2/Artifacts.zip",
                 "extract": "paper-mixins-master.jar"
             },
             "plugins/CommandSpy.jar": {

--- a/server.properties
+++ b/server.properties
@@ -1,10 +1,12 @@
 #Minecraft server properties
-#Wed Oct 08 00:00:00 UTC 2025
+#Tue Jun 16 00:00:00 UTC 2026
 accepts-transfers=true
 allow-flight=true
 broadcast-console-to-ops=true
 broadcast-rcon-to-ops=true
 bug-report-link=
+chat-spam-threshold-seconds=10
+command-spam-threshold-seconds=10
 debug=false
 difficulty=easy
 enable-code-of-conduct=false


### PR DESCRIPTION
The only thing that's broken right now is Geyser, however FAWE hasn't explicitly added support for 26.2 yet, so it's probably better to wait for them to release an update too.